### PR TITLE
Support for external vm and update ip on vm start

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,3 +17,7 @@ releases:
   v0.5.0:
     * Support for reuse external network
     * Support for kvm virtualization in embeded examples
+
+  v0.6.0:
+    * Support for dump full vm snapshot to fs on backup
+    * Update start action for fill in `network` in vm runtime properties

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,3 +23,6 @@ releases:
     * Update start action for fill in `network` in vm runtime properties
     * Cluster Example: Automatically add libvirt host to trusted
     * Support for reuse external vm
+    * move use_external_resource to top of instance properties
+    * add `update` action for sync vm size to values from runtime properties.
+    * rename `memory_size` to `memory_maxsize`

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,3 +21,5 @@ releases:
   v0.6.0:
     * Support for dump full vm snapshot to fs on backup
     * Update start action for fill in `network` in vm runtime properties
+    * Cluster Example: Automatically add libvirt host to trusted
+    * Support for reuse external vm

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Description for VM
 **Supported properties:**
 * `libvirt_auth`: connection url, by default: `qemu:///system`
 * `backup_dir`: directory for save backups, by default: `./`
+* `params`: params used for create object, useful for embeded template.
+  * `vcpu`: CPU count
+  * `memory_minsize`: (optional) recomended VM memory size in KiB for downgrade.
+  * `memory_size`: VM memory size in KiB
+  * `nvram`: (optional) path to nvram (useful for arm)
+  * `disks`: list connected disks
+  * `networks`: list connected networks
+  * `full_dump`: make full dump for backups with memory snapshot to dump file.
+    On create/restore backup will be removed all snapshots in domain.
+  * `wait_for_ip`: (optional) wait until we have some private ip on interfaces
+    The default is `true`.
+  * `domain_type`: (optional) type of virtualization. The default is `qemu`
 
 **Inputs for actions:**
 * `configure`:

--- a/README.md
+++ b/README.md
@@ -188,3 +188,5 @@ You should to install [libvirt-devel](examples/bootstraps/centos.sh#L2) before c
 
 ## TODO:
 * Add more examples with different vm struct and archictures: mips, powerpc
+* Implement storage volume/pool
+* Implement firewall rules

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Description for VM
 **Supported properties:**
 * `libvirt_auth`: connection url, by default: `qemu:///system`
 * `backup_dir`: directory for save backups, by default: `./`
+* `use_external_resource`: (optional) Use external object. The default is
+  `false`.
+* `resource_id`: (optional) Used to identify the object when
+  `use_external_resource` is true.
 * `params`: params used for create object, useful for embeded template.
-  * `use_external_resource`: (optional) Use external object. The default is
-    `false`.
-  * `resource_id`: (optional) Used to identify the object when
-    `use_external_resource` is true.
   * `vcpu`: CPU count
-  * `memory_minsize`: (optional) recomended VM memory size in KiB for
-    downgrade.
   * `memory_size`: VM memory size in KiB
+  * `memory_maxsize`: (optional) recomended VM memory size in KiB for
+        downgrade. The default is value from `memory_size` * 2.
   * `nvram`: (optional) path to nvram (useful for arm)
   * `disks`: list connected disks
   * `networks`: list connected networks
@@ -75,11 +75,11 @@ Description for Network
 **Supported properties:**
 * `libvirt_auth`: connection url, by default: `qemu:///system`
 * `backup_dir`: directory for save backups, by default: `./`
+* `use_external_resource`: (optional) Use external object. The default is
+  `false`.
+* `resource_id`: (optional) Used to identify the object when
+  `use_external_resource` is true.
 * `params`: params used for create object.
-  * `use_external_resource`: (optional) Use external object. The default is
-    `false`.
-  * `resource_id`: (optional) Used to identify the object when
-    `use_external_resource` is true.
   * `dev`: Device name
   * `forwards`: settings for network `forwards`.
   * `ips`: settings for network `ips`.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,13 @@ Description for VM
 * `libvirt_auth`: connection url, by default: `qemu:///system`
 * `backup_dir`: directory for save backups, by default: `./`
 * `params`: params used for create object, useful for embeded template.
+  * `use_external_resource`: (optional) Use external object. The default is
+    `false`.
+  * `resource_id`: (optional) Used to identify the object when
+    `use_external_resource` is true.
   * `vcpu`: CPU count
-  * `memory_minsize`: (optional) recomended VM memory size in KiB for downgrade.
+  * `memory_minsize`: (optional) recomended VM memory size in KiB for
+    downgrade.
   * `memory_size`: VM memory size in KiB
   * `nvram`: (optional) path to nvram (useful for arm)
   * `disks`: list connected disks
@@ -57,7 +62,8 @@ Description for VM
 **Inputs for actions:**
 * `configure`:
   * `params`: list of params for template, can be empty
-  * `domain_file`: Template for domain. Defaults is [domain.xml](cloudify_libvirt/templates/domain.xml)
+  * `domain_file`: Template for domain. Defaults is
+    [domain.xml](cloudify_libvirt/templates/domain.xml)
 
 **Runtime properties:**
 * `resource_id`: resource name.
@@ -70,8 +76,10 @@ Description for Network
 * `libvirt_auth`: connection url, by default: `qemu:///system`
 * `backup_dir`: directory for save backups, by default: `./`
 * `params`: params used for create object.
-  * `use_external_resource`: (optional) Use external object. The default is `false`.
-  * `resource_id`: (optional) Used to identify the object when `use_external_resource` is true.
+  * `use_external_resource`: (optional) Use external object. The default is
+    `false`.
+  * `resource_id`: (optional) Used to identify the object when
+    `use_external_resource` is true.
   * `dev`: Device name
   * `forwards`: settings for network `forwards`.
   * `ips`: settings for network `ips`.
@@ -79,7 +87,8 @@ Description for Network
 **Inputs for actions:**
 * `create`:
   * `params`: list of params for template, can be empty
-  * `network_file`: Template for network. Defaults is [network.xml](cloudify_libvirt/templates/network.xml)
+  * `network_file`: Template for network. Defaults is
+    [network.xml](cloudify_libvirt/templates/network.xml)
 
 **Runtime properties:**
 * `resource_id`: resource name.

--- a/cloudify_libvirt/common.py
+++ b/cloudify_libvirt/common.py
@@ -70,3 +70,26 @@ def delete_node_state(backup_dir, object_name):
     if not os.path.isfile("{}/{}.xml".format(backup_dir, object_name)):
         return
     os.remove("{}/{}.xml".format(backup_dir, object_name))
+
+
+def get_binary_place(backup_dir, object_name):
+    # return path to binary/directory place
+    return "{}/{}_raw".format(backup_dir, object_name)
+
+
+def check_binary_place(backup_dir, object_name):
+    # check binary/directory place exists
+    return os.path.isfile(get_binary_place(backup_dir, object_name))
+
+
+def create_binary_place(backup_dir):
+    # create binary/directory place
+    if not os.path.isdir(backup_dir):
+        os.makedirs(backup_dir)
+
+
+def delete_binary_place(backup_dir, object_name):
+    # create binary/directory place
+    full_path = get_binary_place(backup_dir, object_name)
+    if os.path.isfile(full_path):
+        os.remove(full_path)

--- a/cloudify_libvirt/common.py
+++ b/cloudify_libvirt/common.py
@@ -31,6 +31,12 @@ def get_libvirt_params(**kwargs):
     template_params.update(ctx.instance.runtime_properties.get('params', {}))
     template_params.update(kwargs.get('params', {}))
     ctx.instance.runtime_properties['params'] = template_params
+
+    # update 'resource_id', 'use_external_resource' from kwargs
+    for field in ['resource_id', 'use_external_resource']:
+        if field in kwargs:
+            ctx.instance.runtime_properties[field] = kwargs[field]
+
     return libvirt_auth, template_params
 
 

--- a/cloudify_libvirt/network_tasks.py
+++ b/cloudify_libvirt/network_tasks.py
@@ -54,9 +54,10 @@ def create(**kwargs):
     template_params = _update_template_params(template_params)
 
     try:
-        if template_params.get("use_external_resource"):
+        if ctx.instance.runtime_properties.get("use_external_resource"):
             # lookup the default network by name
-            network = conn.networkLookupByName(template_params["resource_id"])
+            network = conn.networkLookupByName(
+                ctx.instance.runtime_properties["resource_id"])
             if network is None:
                 raise cfy_exc.NonRecoverableError(
                     'Failed to find the network'

--- a/cloudify_libvirt/network_tasks.py
+++ b/cloudify_libvirt/network_tasks.py
@@ -25,6 +25,21 @@ from pkg_resources import resource_filename
 import cloudify_libvirt.common as common
 
 
+def _update_template_params(template_params):
+    # set all params to default values
+    if not template_params:
+        template_params = {}
+
+    if not template_params:
+        template_params = {}
+
+    if not template_params.get("resource_id"):
+        template_params["resource_id"] = ctx.instance.id
+    if not template_params.get("instance_uuid"):
+        template_params["instance_uuid"] = str(uuid.uuid4())
+    return template_params
+
+
 @operation
 def create(**kwargs):
     ctx.logger.info("Creating new network.")
@@ -36,13 +51,7 @@ def create(**kwargs):
             'Failed to open connection to the hypervisor'
         )
 
-    if not template_params:
-        template_params = {}
-
-    if not template_params.get("resource_id"):
-        template_params["resource_id"] = ctx.instance.id
-    if not template_params.get("instance_uuid"):
-        template_params["instance_uuid"] = str(uuid.uuid4())
+    template_params = _update_template_params(template_params)
 
     try:
         if template_params.get("use_external_resource"):

--- a/cloudify_libvirt/templates/domain.xml
+++ b/cloudify_libvirt/templates/domain.xml
@@ -3,7 +3,7 @@
     <partition>/machine</partition>
   </resource>
   <uuid>{{ instance_uuid }}</uuid>
-  <currentMemory unit="KiB">{{ memory_minsize }}</currentMemory>
+  <currentMemory unit="KiB">{{ memory_size }}</currentMemory>
   <on_poweroff>destroy</on_poweroff>
   <devices>
     <console type="pty" tty="/dev/pts/1">
@@ -56,7 +56,7 @@
     <acpi/>
     <apic/>
   </features>
-  <memory unit="KiB">{{ memory_size }}</memory>
+  <memory unit="KiB">{{ memory_maxsize }}</memory>
   <os>
     <type machine="pc" arch="x86_64">hvm</type>
     <boot dev="hd"/>

--- a/cloudify_libvirt/tests/test_common.py
+++ b/cloudify_libvirt/tests/test_common.py
@@ -91,6 +91,21 @@ class TestCommon(LibVirtCommonTest):
             makedirs.assert_called_with("a")
             isdir.assert_called_with("a")
 
+    def test_create_binary_place(self):
+        isdir = mock.Mock(return_value=False)
+        with mock.patch(
+            "os.path.isdir",
+            isdir
+        ):
+            makedirs = mock.Mock()
+            with mock.patch(
+                "os.makedirs",
+                makedirs
+            ):
+                common.create_binary_place("a")
+            makedirs.assert_called_with("a")
+            isdir.assert_called_with("a")
+
     def test_read_node_state(self):
         # no such file
         isfile = mock.Mock(return_value=False)
@@ -147,6 +162,37 @@ class TestCommon(LibVirtCommonTest):
                 common.delete_node_state("a", "b")
             remove.assert_called_with('a/b.xml')
         isfile.assert_called_with('a/b.xml')
+
+    def test_delete_binary_place(self):
+        # no such file
+        isfile = mock.Mock(return_value=False)
+        with mock.patch(
+            "os.path.isfile",
+            isfile
+        ):
+            remove = mock.Mock()
+            with mock.patch(
+                "os.remove",
+                remove
+            ):
+                common.delete_binary_place("a", "b")
+            remove.assert_not_called()
+        isfile.assert_called_with('a/b_raw')
+
+        # remove file
+        isfile = mock.Mock(return_value=True)
+        with mock.patch(
+            "os.path.isfile",
+            isfile
+        ):
+            remove = mock.Mock()
+            with mock.patch(
+                "os.remove",
+                remove
+            ):
+                common.delete_binary_place("a", "b")
+            remove.assert_called_with('a/b_raw')
+        isfile.assert_called_with('a/b_raw')
 
 
 if __name__ == '__main__':

--- a/cloudify_libvirt/tests/test_common_base.py
+++ b/cloudify_libvirt/tests/test_common_base.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import libvirt
 import unittest
 import mock
 
@@ -79,8 +80,10 @@ class LibVirtCommonTest(unittest.TestCase):
 
         # some strange error
         connect = self._create_fake_connection()
-        connect.networkLookupByName = mock.Mock(side_effect=OSError("e"))
-        connect.lookupByName = mock.Mock(side_effect=OSError("e"))
+        connect.networkLookupByName = mock.Mock(
+            side_effect=libvirt.libvirtError("networkLookupByName"))
+        connect.lookupByName = mock.Mock(
+            side_effect=libvirt.libvirtError("lookupByName"))
         with mock.patch(
             libvirt_open,
             mock.Mock(return_value=connect)
@@ -109,8 +112,10 @@ class LibVirtCommonTest(unittest.TestCase):
 
     def _create_fake_connection(self):
         connect = mock.Mock()
-        connect.networkLookupByName = mock.Mock(return_value=None)
-        connect.lookupByName = mock.Mock(return_value=None)
+        connect.networkLookupByName = mock.Mock(
+            side_effect=libvirt.libvirtError("networkLookupByName"))
+        connect.lookupByName = mock.Mock(
+            side_effect=libvirt.libvirtError("lookupByName"))
         connect.networkCreateXML = mock.Mock(return_value=None)
         connect.defineXML = mock.Mock(return_value=None)
         connect.close = mock.Mock(return_value=None)
@@ -130,10 +135,17 @@ class LibVirtCommonTest(unittest.TestCase):
         current_ctx.set(_ctx)
         return _ctx
 
-    def _test_no_resource_id(self, func):
-        _ctx = self._create_ctx()
+    def _test_no_resource_id(self, func, exception_text=None):
         # no initilized/no resource id
-        func(ctx=_ctx)
+        _ctx = self._create_ctx()
+        if not exception_text:
+            func(ctx=_ctx)
+        else:
+            with self.assertRaisesRegexp(
+                NonRecoverableError,
+                exception_text
+            ):
+                func(ctx=_ctx)
 
     def _test_reused_object(self, func, use_existed=True):
         # check use prexisted object

--- a/cloudify_libvirt/tests/test_domain.py
+++ b/cloudify_libvirt/tests/test_domain.py
@@ -146,9 +146,9 @@ class TestDomainTasks(LibVirtCommonTest):
             _ctx.instance.runtime_properties['params']['memory_size'],
             1024)
 
-
     def test_update(self):
-        self._test_no_resource_id(domain_tasks.update)
+        self._test_no_resource_id(domain_tasks.update,
+                                  "No servers for update")
         self._test_check_correct_connect_action(domain_tasks.update)
         self._test_check_correct_connect_no_object(domain_tasks.update)
         # check memory
@@ -171,7 +171,8 @@ class TestDomainTasks(LibVirtCommonTest):
             params_update={'vcpu': 1024})
 
     def test_reboot(self):
-        self._test_no_resource_id(domain_tasks.reboot)
+        self._test_no_resource_id(domain_tasks.reboot,
+                                  "No servers for reboot")
         self._test_check_correct_connect_action(domain_tasks.reboot)
         self._test_check_correct_connect_no_object(domain_tasks.reboot)
         self._test_action_states(
@@ -180,7 +181,8 @@ class TestDomainTasks(LibVirtCommonTest):
             'Can not reboot guest domain.')
 
     def test_start(self):
-        self._test_no_resource_id(domain_tasks.start)
+        self._test_no_resource_id(domain_tasks.start,
+                                  "No servers for start")
         self._test_check_correct_connect_action(domain_tasks.start)
         self._test_check_correct_connect_no_object(domain_tasks.start)
         self._test_action_states(
@@ -199,7 +201,8 @@ class TestDomainTasks(LibVirtCommonTest):
             'Can not shutdown guest domain.')
 
     def test_resume(self):
-        self._test_no_resource_id(domain_tasks.resume)
+        self._test_no_resource_id(domain_tasks.resume,
+                                  "No servers for resume")
         self._test_check_correct_connect_action(domain_tasks.resume)
         self._test_check_correct_connect_no_object(domain_tasks.resume)
         self._test_action_states(
@@ -208,7 +211,8 @@ class TestDomainTasks(LibVirtCommonTest):
             "Can not suspend guest domain.")
 
     def test_suspend(self):
-        self._test_no_resource_id(domain_tasks.suspend)
+        self._test_no_resource_id(domain_tasks.suspend,
+                                  "No servers for suspend")
         self._test_check_correct_connect_action(domain_tasks.suspend)
         self._test_check_correct_connect_no_object(domain_tasks.suspend)
         self._test_action_states(
@@ -309,7 +313,8 @@ class TestDomainTasks(LibVirtCommonTest):
                 _ctx.instance.runtime_properties.get('resource_id'))
 
     def test_perfomance(self):
-        self._test_no_resource_id(domain_tasks.perfomance)
+        self._test_no_resource_id(domain_tasks.perfomance,
+                                  "No servers for statistics.")
         self._test_check_correct_connect_action(domain_tasks.perfomance)
         self._test_check_correct_connect_no_object(domain_tasks.perfomance)
 
@@ -595,7 +600,8 @@ class TestDomainTasks(LibVirtCommonTest):
                     fake_file().write.assert_called_with("<domain/>")
 
     def test_snapshot_create(self):
-        self._test_common_backups(domain_tasks.snapshot_create)
+        self._test_common_backups(domain_tasks.snapshot_create,
+                                  "No servers for backup.")
 
         # check with without params and custom file
         _ctx = self._create_ctx()
@@ -704,7 +710,8 @@ class TestDomainTasks(LibVirtCommonTest):
                         './snapshot_name/resource.xml', "r")
 
     def test_snapshot_apply(self):
-        self._test_common_backups(domain_tasks.snapshot_apply)
+        self._test_common_backups(domain_tasks.snapshot_apply,
+                                  "No servers for restore.")
 
         # apply snapshot
         _ctx = self._create_ctx()
@@ -793,7 +800,8 @@ class TestDomainTasks(LibVirtCommonTest):
                             './snapshot_name/resource.xml')
 
     def test_snapshot_delete(self):
-        self._test_common_backups(domain_tasks.snapshot_delete)
+        self._test_common_backups(domain_tasks.snapshot_delete,
+                                  "No servers for remove_backup.")
 
         # delete snapshot with error
         _ctx = self._create_ctx()
@@ -876,9 +884,9 @@ class TestDomainTasks(LibVirtCommonTest):
             {'ctx': _ctx, 'snapshot_name': 'snapshot_name',
              'snapshot_incremental': True}, 'resource')
 
-    def _test_common_backups(self, func):
+    def _test_common_backups(self, func, noresource_text):
         # common funcs for backups
-        self._test_no_resource_id(func)
+        self._test_no_resource_id(func, noresource_text)
         self._test_no_snapshot_name(self._create_ctx(), func)
         self._test_snapshot_name_backup(func)
         self._test_check_correct_connect_backup(func)

--- a/cloudify_libvirt/tests/test_network.py
+++ b/cloudify_libvirt/tests/test_network.py
@@ -200,18 +200,6 @@ class TestNetworkTasks(LibVirtCommonTest):
             _ctx.instance.runtime_properties['use_external_resource']
         )
 
-    def _test_reused_network(self, func, use_existed=True):
-        # check use prexisted network
-        _ctx = self._create_ctx()
-        _ctx.instance.runtime_properties['resource_id'] = 'resource'
-        _ctx.instance.runtime_properties['use_external_resource'] = use_existed
-        connect = self._create_fake_connection()
-        with mock.patch(
-            "cloudify_libvirt.network_tasks.libvirt.open",
-            mock.Mock(return_value=connect)
-        ):
-            func(ctx=_ctx)
-
     def _test_empty_network_backup(self, func):
         # check correct handle exception with empty network
         _ctx = self._create_ctx()
@@ -453,7 +441,7 @@ class TestNetworkTasks(LibVirtCommonTest):
         self._test_no_resource_id(network_tasks.delete)
         self._test_empty_connection(network_tasks.delete)
         self._test_empty_network(network_tasks.delete)
-        self._test_reused_network(network_tasks.delete)
+        self._test_reused_object(network_tasks.delete)
 
         # delete with error
         _ctx = self._create_ctx()

--- a/cloudify_libvirt/tests/test_network.py
+++ b/cloudify_libvirt/tests/test_network.py
@@ -171,10 +171,11 @@ class TestNetworkTasks(LibVirtCommonTest):
         _ctx = self._create_ctx()
         self._check_no_such_object_network(
             "cloudify_libvirt.network_tasks.libvirt.open",
-            network_tasks.create, [], {'ctx': _ctx, 'params': {
+            network_tasks.create, [], {
+                'ctx': _ctx,
                 "resource_id": 'resource',
                 "use_external_resource": True,
-            }}, 'resource')
+            }, 'resource')
 
     def test_reuse_network_create_exist(self):
         # check that we can use network
@@ -189,9 +190,9 @@ class TestNetworkTasks(LibVirtCommonTest):
             "cloudify_libvirt.domain_tasks.libvirt.open",
             mock.Mock(return_value=connect)
         ):
-            network_tasks.create(ctx=_ctx, params={
-                    "resource_id": 'resource',
-                    "use_external_resource": True})
+            network_tasks.create(ctx=_ctx,
+                                 resource_id='resource',
+                                 use_external_resource=True)
         connect.networkLookupByName.assert_called_with('resource')
         self.assertEqual(
             _ctx.instance.runtime_properties['resource_id'], 'resource'

--- a/cloudify_libvirt/tests/test_network.py
+++ b/cloudify_libvirt/tests/test_network.py
@@ -225,7 +225,8 @@ class TestNetworkTasks(LibVirtCommonTest):
         return _ctx, connect, network
 
     def test_snapshot_apply(self):
-        self._test_no_resource_id(network_tasks.snapshot_apply)
+        self._test_no_resource_id(network_tasks.snapshot_apply,
+                                  "No network for restore")
         self._test_no_snapshot_name(self._create_ctx(),
                                     network_tasks.snapshot_apply)
         self._test_empty_connection_backup(network_tasks.snapshot_apply)
@@ -294,7 +295,8 @@ class TestNetworkTasks(LibVirtCommonTest):
                 fake_file.assert_called_with('./backup!/resource.xml', 'r')
 
     def test_snapshot_create(self):
-        self._test_no_resource_id(network_tasks.snapshot_create)
+        self._test_no_resource_id(network_tasks.snapshot_create,
+                                  "No network for backup")
         self._test_no_snapshot_name(self._create_ctx(),
                                     network_tasks.snapshot_create)
         self._test_empty_connection_backup(network_tasks.snapshot_create)
@@ -363,7 +365,8 @@ class TestNetworkTasks(LibVirtCommonTest):
                     fake_file().write.assert_called_with("<network/>")
 
     def test_snapshot_delete(self):
-        self._test_no_resource_id(network_tasks.snapshot_delete)
+        self._test_no_resource_id(network_tasks.snapshot_delete,
+                                  "No network for backup delete")
         self._test_no_snapshot_name(self._create_ctx(),
                                     network_tasks.snapshot_delete)
 

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -1,10 +1,10 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.3.1/types.yaml
+  - http://www.getcloudify.org/spec/cloudify/4.4/types.yaml
   - http://www.getcloudify.org/spec/fabric-plugin/1.5.1/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.2/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.5.0/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.5/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.6.0/plugin.yaml
 
 inputs:
   # agent settings
@@ -269,7 +269,8 @@ node_templates:
               - action: cfy profile use localhost -u admin -p admin -t default_tenant
               - action: cfy plugins bundle-upload
               - action: cfy plugin upload -y https://github.com/cloudify-incubator/cloudify-utilities-plugin/releases/download/1.9.2/plugin.yaml http://repository.cloudifysource.org/cloudify/wagons/cloudify-utilities-plugin/1.9.2/cloudify_utilities_plugin-1.9.2-py27-none-linux_x86_64-centos-Core.wgn
-              - action: cfy plugin upload -y https://github.com/cloudify-incubator/cloudify-libvirt-plugin/releases/download/0.5.0/plugin.yaml https://github.com/cloudify-incubator/cloudify-libvirt-plugin/releases/download/0.5.0/cloudify_libvirt_plugin-0.5.0-py27-none-linux_x86_64-centos-Core.wgn
+              - action: cfy plugin upload -y https://github.com/cloudify-incubator/cloudify-utilities-plugin/releases/download/1.9.5/plugin.yaml http://repository.cloudifysource.org/cloudify/wagons/cloudify-utilities-plugin/1.9.5/cloudify_utilities_plugin-1.9.5-py27-none-linux_x86_64-centos-Core.wgn
+              - action: cfy plugin upload -y https://github.com/cloudify-incubator/cloudify-libvirt-plugin/releases/download/0.6.0/plugin.yaml https://github.com/cloudify-incubator/cloudify-libvirt-plugin/releases/download/0.6.0/cloudify_libvirt_plugin-0.6.0-py27-none-linux_x86_64-centos-Core.wgn
               - action: cfy plugin upload -y https://github.com/cloudify-incubator/cloudify-kubernetes-plugin/releases/download/2.3.1/plugin.yaml https://github.com/cloudify-incubator/cloudify-kubernetes-plugin/releases/download/2.3.1/cloudify_kubernetes_plugin-2.3.1-py27-none-linux_x86_64-centos-Core.wgn
               # set secrets
               - action: sudo cfy secret create agent_key_private -u -f /etc/cloudify/kvm.key

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -21,9 +21,6 @@ inputs:
   disk_size:
     default: 80GB
 
-  agent_private_key:
-    default: { get_secret: agent_private_key }
-
   # cluster(kvm) settings
   cluster_user:
     type: string
@@ -151,7 +148,7 @@ node_templates:
           - path: /etc/cloudify/kvm.key
             owner: cfyuser:cfyuser
             permissions: '0400'
-            content: { get_input: agent_private_key }
+            content: { get_input: agent_key_private }
           - path: /etc/cloudify/kvm.key.pub
             owner: cfyuser:cfyuser
             permissions: '0400'
@@ -234,7 +231,7 @@ node_templates:
       use_public_ip: true
       agent_config:
         user: { get_input: agent_user }
-        key: { get_input: agent_private_key }
+        key: { get_input: agent_key_private }
         install_method: remote
     interfaces:
       cloudify.interfaces.lifecycle:
@@ -247,7 +244,7 @@ node_templates:
             terminal_auth: &terminal_auth
               user: { get_input: agent_user }
               ip: { get_attribute: [SELF, ip] }
-              key_content: { get_input: agent_private_key }
+              key_content: { get_input: agent_key_private }
               port: 22
               promt_check:
                 - '$'
@@ -265,6 +262,15 @@ node_templates:
               - action: sudo usermod -a -G libvirt cfyuser
               - action: sudo usermod -a -G kvm cfyuser
               - action: sudo usermod -a -G qemu cfyuser
+              # enable ssh connect
+              - action: sudo mkdir -p /etc/cloudify/.ssh/
+              # enable write for current user, will fix on next step
+              - action: sudo chmod 777 -R /etc/cloudify/.ssh
+              # dump ssh key to known_hsot
+              - action: {concat:["sudo ssh-keyscan -H ", { get_input: cluster_host }, " >> /etc/cloudify/.ssh/known_hosts"]}
+              - action: sudo chmod 700 /etc/cloudify/.ssh
+              - action: sudo chmod 600 /etc/cloudify/.ssh/known_hosts
+              - action: sudo chown cfyuser:cfyuser -R /etc/cloudify/.ssh
               # upload plugins
               - action: cfy profile use localhost -u admin -p admin -t default_tenant
               - action: cfy plugins bundle-upload

--- a/examples/templates/domain-arm.xml
+++ b/examples/templates/domain-arm.xml
@@ -3,7 +3,7 @@
     <partition>/machine</partition>
   </resource>
   <uuid>{{ instance_uuid }}</uuid>
-  <currentMemory unit="KiB">{{ memory_minsize }}</currentMemory>
+  <currentMemory unit="KiB">{{ memory_size }}</currentMemory>
   <on_poweroff>destroy</on_poweroff>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>
@@ -66,7 +66,7 @@
   <features>
     <gic version='2'/>
   </features>
-  <memory unit="KiB">{{ memory_size }}</memory>
+  <memory unit="KiB">{{ memory_maxsize }}</memory>
   <os>
     <type arch='aarch64' machine='virt'>hvm</type>
     <loader readonly='yes' type='pflash'>/usr/share/AAVMF/AAVMF_CODE.fd</loader>

--- a/examples/vm_agent.yaml
+++ b/examples/vm_agent.yaml
@@ -61,7 +61,7 @@ inputs:
 relationships:
 
   vm_connected_to_storage:
-    derived_from: cloudify.relationships.contained_in
+    derived_from: cloudify.relationships.depends_on
     target_interfaces:
       cloudify.interfaces.relationship_lifecycle:
         preconfigure:
@@ -72,7 +72,7 @@ relationships:
 node_types:
 
   agent_domain:
-    derived_from: cloudify.nodes.Compute
+    derived_from: cloudify.nodes.WebServer
     properties:
       use_public_ip:
         default: false
@@ -114,16 +114,8 @@ node_templates:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            params:
-              dev: virbr1
-              forwards:
-                - mode: nat
-              ips:
-                - address: 192.168.141.1
-                  netmask: 255.255.255.0
-                  dhcp:
-                    start: 192.168.141.2
-                    end: 192.168.141.254
+            resource_id: { get_secret: libvirt_common_network }
+            use_external_resource: true
     relationships:
     - target: vm_download
       type: cloudify.relationships.depends_on
@@ -176,7 +168,9 @@ node_templates:
     properties:
       libvirt_auth: *libvirt_auth
       agent_config:
-        install_method: none
+        user: { get_input: agent_user }
+        key: { get_input: agent_key_private }
+        install_method: remote
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
@@ -219,16 +213,11 @@ node_templates:
     type: agent_domain
     properties:
       use_public_ip: true
-      agent_config:
-        user: { get_input: agent_user }
-        key: { get_input: agent_key_private }
-        install_method: remote
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
-          implementation: scripts/vm_fillip.py
-          executor: central_deployment_agent
-        start:
+          implementation: scripts/vm_check.py
+        configure:
           implementation: terminal.cloudify_terminal.tasks.run
           inputs:
             terminal_auth: &terminal_auth
@@ -244,22 +233,14 @@ node_templates:
               - action: sudo yum install -y openssl-1.0.2k deltarpm
               # space fix
               - action: sudo sudo xfs_growfs /
+        start:
+          implementation: scripts/vm_fillip.py
+          executor: central_deployment_agent
     relationships:
       - target: base_vm
-        type: cloudify.relationships.depends_on
+        type: cloudify.relationships.contained_in
       - target: floating_ip
         type: cloudify.relationships.depends_on
-
-  example_node:
-    type: cloudify.nodes.WebServer
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        configure:
-          implementation: scripts/vm_check.py
-    relationships:
-      - target: qemu_vm
-        type: cloudify.relationships.contained_in
-
 
 groups:
 

--- a/examples/vm_agent.yaml
+++ b/examples/vm_agent.yaml
@@ -18,8 +18,8 @@ inputs:
   disk_size:
     default: 24GB
 
-  agent_private_key:
-    default: { get_secret: agent_private_key }
+  agent_key_private:
+    default: { get_secret: agent_key_private }
 
   # cluster(kvm) settings
   cluster_user:
@@ -221,7 +221,7 @@ node_templates:
       use_public_ip: true
       agent_config:
         user: { get_input: agent_user }
-        key: { get_input: agent_private_key }
+        key: { get_input: agent_key_private }
         install_method: remote
     interfaces:
       cloudify.interfaces.lifecycle:
@@ -234,7 +234,7 @@ node_templates:
             terminal_auth: &terminal_auth
               user: { get_input: agent_user }
               ip: { get_attribute: [SELF, ip] }
-              key_content: { get_input: agent_private_key }
+              key_content: { get_input: agent_key_private }
               port: 22
               promt_check:
                 - '$'

--- a/examples/vm_agent.yaml
+++ b/examples/vm_agent.yaml
@@ -1,10 +1,10 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.3.1/types.yaml
+  - http://www.getcloudify.org/spec/cloudify/4.4/types.yaml
   - http://www.getcloudify.org/spec/fabric-plugin/1.5.1/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.2/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.5.0/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.5/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.6.0/plugin.yaml
 
 inputs:
   # agent settings

--- a/examples/vm_centos.amd64.yaml
+++ b/examples/vm_centos.amd64.yaml
@@ -1,9 +1,9 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.3.1/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.2/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.5.0/plugin.yaml
+  - http://www.getcloudify.org/spec/cloudify/4.4/types.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.5/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.6.0/plugin.yaml
 
 inputs:
 
@@ -111,3 +111,39 @@ node_templates:
         type: cloudify.libvirt.relationships.connected_to
       - target: disk_clone
         type: vm_connected_to_storage
+
+  example_node:
+    type: cloudify.nodes.WebServer
+    interfaces:
+      cloudify.interfaces.lifecycle:
+          create:
+            implementation: terminal.cloudify_terminal.tasks.run
+            inputs:
+              terminal_auth:
+                user: centos
+                password: { get_input: agent_password }
+                ip: { get_attribute: [qemu_vm, ip] }
+              calls:
+              - action: uname -a
+      cloudify.interfaces.freeze:
+          fs_prepare:
+            implementation: terminal.cloudify_terminal.tasks.run
+            inputs:
+              terminal_auth:
+                user: centos
+                password: { get_input: agent_password }
+                ip: { get_attribute: [qemu_vm, ip] }
+              calls:
+              - action: sudo sync
+          fs_finalize:
+            implementation: terminal.cloudify_terminal.tasks.run
+            inputs:
+              terminal_auth:
+                user: centos
+                password: { get_input: agent_password }
+                ip: { get_attribute: [qemu_vm, ip] }
+              calls:
+              - action: sudo sync
+    relationships:
+      - target: qemu_vm
+        type: cloudify.relationships.contained_in

--- a/examples/vm_centos.amd64.yaml
+++ b/examples/vm_centos.amd64.yaml
@@ -157,9 +157,13 @@ node_templates:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
+            use_external_resource: true
+            resource_id: { get_attribute: [qemu_vm, resource_id] }
+        start:
+          implementation: libvirt.cloudify_libvirt.domain_tasks.update
+          inputs:
             params:
-              use_external_resource: true
-              resource_id: { get_attribute: [qemu_vm, resource_id] }
+              memory_size: 393216
     relationships:
       - target: example_node
         type: cloudify.relationships.depends_on

--- a/examples/vm_centos.amd64.yaml
+++ b/examples/vm_centos.amd64.yaml
@@ -147,3 +147,19 @@ node_templates:
     relationships:
       - target: qemu_vm
         type: cloudify.relationships.contained_in
+
+  reuse_vm:
+    type: cloudify.libvirt.domain
+    properties:
+      agent_config:
+        install_method: none
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            params:
+              use_external_resource: true
+              resource_id: { get_attribute: [qemu_vm, resource_id] }
+    relationships:
+      - target: example_node
+        type: cloudify.relationships.depends_on

--- a/examples/vm_ssh.amd64.yaml
+++ b/examples/vm_ssh.amd64.yaml
@@ -1,9 +1,9 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.3.1/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.2/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.5.0/plugin.yaml
+  - http://www.getcloudify.org/spec/cloudify/4.4/types.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.5/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.6.0/plugin.yaml
 
 inputs:
 

--- a/examples/vm_ssh.arm64.yaml
+++ b/examples/vm_ssh.arm64.yaml
@@ -1,9 +1,9 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.3.1/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.2/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.5.0/plugin.yaml
+  - http://www.getcloudify.org/spec/cloudify/4.4/types.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.9.5/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-libvirt-plugin/0.6.0/plugin.yaml
 
 inputs:
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,6 +7,34 @@ plugins:
 
 data_types:
 
+  network_params:
+    properties:
+      use_external_resource:
+        required: false
+        default: false
+        description: >
+          Use external object. The default is `false`.
+      resource_id:
+        required: false
+        default: ""
+        description: >
+          Used to identify the object when `use_external_resource` is true.
+      dev:
+        required: false
+        default: ""
+        description: >
+          Device name
+      forwards:
+        required: false
+        default: []
+        description: >
+          Settings for network `forwards`.
+      ips:
+        required: false
+        default: []
+        description: >
+          Settings for network `ips`.
+
   domain_params:
     properties:
       vcpu:
@@ -40,10 +68,14 @@ data_types:
           List connected networks
         default: []
       full_dump:
+        default: false
         description: >
           Make full dump for backups with memory snapshot to dump file.
           On create/restore backup will be removed all snapshots in domain.
-        default: False
+      wait_for_ip:
+        default: true
+        description: >
+          Wait until we have some private ip on interfaces
       domain_type:
         description: >
           Type of virtualization
@@ -70,6 +102,9 @@ node_types:
           inputs: {}
         start:
           implementation: libvirt.cloudify_libvirt.domain_tasks.start
+          inputs: {}
+        reboot:
+          implementation: libvirt.cloudify_libvirt.domain_tasks.reboot
           inputs: {}
         stop:
           implementation: libvirt.cloudify_libvirt.domain_tasks.stop
@@ -109,6 +144,8 @@ node_types:
         default: './'
       libvirt_auth:
         default: 'qemu:///system'
+      params:
+        type: network_params
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,8 +2,8 @@ plugins:
   libvirt:
     executor: central_deployment_agent
     package_name: cloudify-libvirt-plugin
-    package_version: '0.5.0'
-    source: https://github.com/cloudify-incubator/cloudify-libvirt-plugin/archive/0.5.0.zip
+    package_version: '0.6.0'
+    source: https://github.com/cloudify-incubator/cloudify-libvirt-plugin/archive/0.6.0.zip
 
 data_types:
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -37,6 +37,16 @@ data_types:
 
   domain_params:
     properties:
+      use_external_resource:
+        required: false
+        default: false
+        description: >
+          Use external object. The default is `false`.
+      resource_id:
+        required: false
+        default: ""
+        description: >
+          Used to identify the object when `use_external_resource` is true.
       vcpu:
         required: false
         type: integer

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,16 +9,6 @@ data_types:
 
   network_params:
     properties:
-      use_external_resource:
-        required: false
-        default: false
-        description: >
-          Use external object. The default is `false`.
-      resource_id:
-        required: false
-        default: ""
-        description: >
-          Used to identify the object when `use_external_resource` is true.
       dev:
         required: false
         default: ""
@@ -37,31 +27,21 @@ data_types:
 
   domain_params:
     properties:
-      use_external_resource:
-        required: false
-        default: false
-        description: >
-          Use external object. The default is `false`.
-      resource_id:
-        required: false
-        default: ""
-        description: >
-          Used to identify the object when `use_external_resource` is true.
       vcpu:
         required: false
         type: integer
         description: >
           CPU count
-      memory_minsize:
-        required: false
-        type: integer
-        description: >
-          Recomended VM memory size in KiB for downgrade
       memory_size:
         required: false
         type: integer
         description: >
           VM memory size in KiB
+      memory_maxsize:
+        required: false
+        type: integer
+        description: >
+          Recomended VM memory size in KiB for upgrade
       nvram:
         required: false
         type: string
@@ -96,6 +76,16 @@ node_types:
   cloudify.libvirt.domain:
     derived_from: cloudify.nodes.Compute
     properties:
+      use_external_resource:
+        required: false
+        default: false
+        description: >
+          Use external object. The default is `false`.
+      resource_id:
+        required: false
+        default: ""
+        description: >
+          Used to identify the object when `use_external_resource` is true.
       backup_dir:
         default: './'
       libvirt_auth:
@@ -113,8 +103,13 @@ node_types:
         start:
           implementation: libvirt.cloudify_libvirt.domain_tasks.start
           inputs: {}
+        # reboot vm
         reboot:
           implementation: libvirt.cloudify_libvirt.domain_tasks.reboot
+          inputs: {}
+        # update vm cpu/memory
+        update:
+          implementation: libvirt.cloudify_libvirt.domain_tasks.update
           inputs: {}
         stop:
           implementation: libvirt.cloudify_libvirt.domain_tasks.stop
@@ -150,6 +145,16 @@ node_types:
   cloudify.libvirt.network:
     derived_from: cloudify.nodes.Network
     properties:
+      use_external_resource:
+        required: false
+        default: false
+        description: >
+          Use external object. The default is `false`.
+      resource_id:
+        required: false
+        default: ""
+        description: >
+          Used to identify the object when `use_external_resource` is true.
       backup_dir:
         default: './'
       libvirt_auth:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,6 +5,50 @@ plugins:
     package_version: '0.5.0'
     source: https://github.com/cloudify-incubator/cloudify-libvirt-plugin/archive/0.5.0.zip
 
+data_types:
+
+  domain_params:
+    properties:
+      vcpu:
+        required: false
+        type: integer
+        description: >
+          CPU count
+      memory_minsize:
+        required: false
+        type: integer
+        description: >
+          Recomended VM memory size in KiB for downgrade
+      memory_size:
+        required: false
+        type: integer
+        description: >
+          VM memory size in KiB
+      nvram:
+        required: false
+        type: string
+        description: >
+          Path to nvram
+      disks:
+        required: false
+        description: >
+          List connected disks
+        default: []
+      networks:
+        required: false
+        description: >
+          List connected networks
+        default: []
+      full_dump:
+        description: >
+          Make full dump for backups with memory snapshot to dump file.
+          On create/restore backup will be removed all snapshots in domain.
+        default: False
+      domain_type:
+        description: >
+          Type of virtualization
+        default: qemu
+
 node_types:
 
   cloudify.libvirt.domain:
@@ -14,6 +58,8 @@ node_types:
         default: './'
       libvirt_auth:
         default: 'qemu:///system'
+      params:
+        type: domain_params
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-libvirt-plugin',
-    version='0.5.0',
+    version='0.6.0',
     description='support libvirt',
     author='Cloudify',
     author_email='hello@getcloudify.org',


### PR DESCRIPTION
* Support for dump full vm snapshot to fs on backup
* Update start action for fill in `network` in vm runtime properties
* Cluster Example: Automatically add libvirt host to trusted
* Support for reuse external vm