### PR TITLE
Fix

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -357,7 +357,7 @@ node_types:
           implementation: libvirt.cloudify_libvirt.volume_tasks.create
           inputs:
             params:
-              type: cloudify.datatypes.volume
+              default: {}
             template_resource:
               default: ''
             template_content:


### PR DESCRIPTION
Message
'install' workflow execution failed: Value {'pool': {'get_attribute': ['vm_pool', 'resource_id']}, 'capacity': 1, 'allocation': 1, 'type': 'cloudify.datatypes.volume'} of 'params' does not match the definition: cloudify.datatypes.volum